### PR TITLE
fix: default sql_uri doesn't work

### DIFF
--- a/hetznerbot/config.py
+++ b/hetznerbot/config.py
@@ -11,7 +11,7 @@ default_config = {
         "admin": "nukesor",
     },
     "database": {
-        "sql_uri": "sqlite:///hetznerbot",
+        "sql_uri": "sqlite:///hetznerbot.db",
     },
     "logging": {
         "sentry_enabled": False,


### PR DESCRIPTION
simply running the commands from the readme didn't work for creating a new instance. had to modify the `sql_uri` for sqlite not to complain